### PR TITLE
Default gateway

### DIFF
--- a/app.json
+++ b/app.json
@@ -20,7 +20,8 @@
       "value": "https://YOURAPPNAME.herokuapp.com"
     },
     "IPFS_GATEWAY_URL": {
-      "description": "The HTTPS URL of your prefered IPFS gateway.  Defaults to https://ipfs.io/ipfs",
+      "description": "The HTTPS URL of your prefered IPFS gateway (defaults to https://ipfs.io)",
+      "value": "https://ipfs.runfission.com",
       "required": false
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "casper": "github:tryghost/Casper#3.0.4",
     "ghost": "~3.1.0",
-    "ghost-storage-adapter-ipfs": "github:fission-suite/ghost-storage-adapter-ipfs",
+    "ghost-storage-adapter-ipfs": "github:fission-suite/ghost-storage-adapter-ipfs#gateway-enhancement",
     "mysql": "~2.17.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "casper": "github:tryghost/Casper#3.0.4",
     "ghost": "~3.1.0",
-    "ghost-storage-adapter-ipfs": "github:fission-suite/ghost-storage-adapter-ipfs#gateway-enhancement",
+    "ghost-storage-adapter-ipfs": "github:fission-suite/ghost-storage-adapter-ipfs",
     "mysql": "~2.17.1"
   },
   "engines": {


### PR DESCRIPTION
Populates the gateway environment variable with Fissions gateway url.

The environment variable is still optional (required false) meaning the user could leave the variable blank.  If blank, the default gateway from the Ghost adapter (ipfs.io) will be used instead.

The gateway is handled separately from the apiURL