### PR TITLE
make heroku button work when referrer is blocked

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Ghost is a free, open, simple blogging platform. Visit the project's website at <http://ghost.org>, or read the docs on <http://support.ghost.org>.
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/fission-suite/heroku-ipfs-ghost)
 
 ## Ghost v3.x
 


### PR DESCRIPTION
Heroku gets the template URL from the HTTP `referer` parameter, which some browsers (like [Brave](https://github.com/brave/brave-browser/issues/4707)) and extensions block. Adding it as an explicit URL parameter makes it work again.